### PR TITLE
Handle missing/unsuitable `bash`/`coreutils` gracefully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
           echo $PATH | grep "foo" || exit 3
 
       # Note that `bash` is *not* on the path now..
-      - run: |
+      - if: ${{ matrix.shellSource == 'flakes' }}
+        run: |
           ! command -v bash
 
       - name: 'Run Script with Host Env'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
           # Check that modifications in `shellHook` take effect:
           echo $PATH | grep "foo" || exit 3
 
-      # Restore `bash` and friends into the environment:
+      # Note that `bash` is *not* on the path now..
       - run: |
-          { echo "/bin"; echo "/usr/bin"; } >> $GITHUB_PATH
+          ! command -v bash
 
       - name: 'Run Script with Host Env'
         uses: ./.github/workflows/matrix-expansion-helper
@@ -81,6 +81,14 @@ jobs:
           command -v tiny && exit 3 || :
 
           cat foo # check that the script actually ran
+
+      # Test that we can run with non-interactive bash on $PATH:
+      - name: 'Put non-interactive bash on $PATH'
+        uses: ./
+        with:
+          packages: bash
+      - run: |
+          ! bash -c "type compgen"
 
       - name: 'Run Script without Host Env'
         uses: ./.github/workflows/matrix-expansion-helper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
           echo $PATH | grep "foo" || exit 3
 
       # Note that `bash` is *not* on the path now..
+      #
+      # (but only for the flakes route since that's the only route here that's
+      # not `mkShell` based and thus doesn't dump the stdenv's bash/coreutils on
+      # $PATH)
       - if: ${{ matrix.shellSource == 'flakes' }}
         run: |
           ! command -v bash
@@ -81,7 +85,7 @@ jobs:
         run: |
           command -v tiny && exit 3 || :
 
-          cat foo # check that the script actually ran
+          [[ -e foo ]] # check that the script actually ran
 
       # Test that we can run with non-interactive bash on $PATH:
       - name: 'Put non-interactive bash on $PATH'

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
       if: steps.try-bash.outcome == 'failure'
       shell: '/usr/bin/bash {0}'
       run: |
-        /usr/bin/test-not-bash -c "type compgen &>/dev/null" || exit 2
+        /usr/bin/bash -c "type compgen &>/dev/null" || exit 2
 
         echo '::notice::bash not on $PATH, using /usr/bin/bash...'
         echo "bash=/usr/bin/bash" >> $GITHUB_OUTPUT
@@ -115,6 +115,7 @@ runs:
       run: |
         BASH_PATH="${{ (steps.try-bash.outcome == 'success' && steps.try-bash.outputs.bash) || (steps.try-hardcoded-bash.outcome == 'success' && steps.try-hardcoded-bash.outputs.bash) || (steps.try-nix-shell-bash.outcome == 'success' && steps.try-nix-shell-bash.outputs.bash) || 'unreachable' }}"
         echo "bash=${BASH_PATH} --noprofile --norc -e -o pipefail {0}" >> $GITHUB_OUTPUT
+        echo "bash-binary-path=${BASH_PATH}" >> $GITHUB_OUTPUT
 
     - id: check-for-nix
       shell: ${{ steps.bash-path.outputs.bash }}
@@ -161,10 +162,11 @@ runs:
     #
     # So, to keep things fast and simple we just vendored the `nix-direnv`
     # envrc script.
-    - run: ${{ github.action_path }}/action.bash ${{ github.env }} ${{ github.path }}
+    - run: ${{steps.bash-path.outputs.bash-binary-path }} ${{ github.action_path }}/action.bash ${{ github.env }} ${{ github.path }}
       shell: ${{ steps.bash-path.outputs.bash }}
       env:
         NIX_DIRENV_PATH: ${{ github.action_path }}/vendored/nix-direnv.envrc
+        BASH_BINARY_PATH: ${{ steps.bash-path.outputs.bash-binary-path }}
 
         INPUT_EXPORT_ENV: ${{ inputs.exportEnv }}
         INPUT_PRESERVE_DEFAULT_PATH: ${{ inputs.preserveDefaultPath }}

--- a/action.yml
+++ b/action.yml
@@ -70,8 +70,54 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: check-for-nix
+    # `type compgen` is used to check for bash-interactive which `action.bash`
+    # needs (it uses `compgen`).
+    #
+    # Note: we need `continue-on-error` otherwise subsequent commands won't run
+    # and we need `steps.... == 'failure'` gates on these commands so they don't
+    # run when the previous test _didn't_ fail. Unfortunate but what to do.
+    - id: try-bash
+      continue-on-error: true
       shell: bash
+      run: |
+        command -v bash || exit 1
+        type compgen &>/dev/null || exit 2
+        echo "bash=$(command -v bash)" >> $GITHUB_OUTPUT
+    - id: try-hardcoded-bash
+      continue-on-error: true
+      if: steps.try-bash.outcome == 'failure'
+      shell: '/usr/bin/bash {0}'
+      run: |
+        /usr/bin/test-not-bash -c "type compgen &>/dev/null" || exit 2
+
+        echo '::notice::bash not on $PATH, using /usr/bin/bash...'
+        echo "bash=/usr/bin/bash" >> $GITHUB_OUTPUT
+    - id: try-nix-shell-bash
+      continue-on-error: true
+      if: steps.try-hardcoded-bash.outcome == 'failure'
+      shell: 'nix-shell {0}'
+      run: |
+        { nixpkgs ? import <nixpkgs> {} }: with nixpkgs; mkShell {
+          shellHook = ''
+            echo '::notice::using bash from `nixpkgs`...'
+            echo "bash=${lib.getExe bashInteractive}" >> $GITHUB_OUTPUT
+          '';
+        }
+
+    - name: "error: no bash found"
+      if: steps.try-nix-shell-bash.outcome == 'failure'
+      # Note: *not* continue on error; this is the end of the chain.
+      shell: sh
+      run: echo "::error::no suitable bash found!" && exit 4
+
+    - id: bash-path
+      shell: "${{ (steps.try-bash.outcome == 'success' && steps.try-bash.outputs.bash) || (steps.try-hardcoded-bash.outcome == 'success' && steps.try-hardcoded-bash.outputs.bash) || (steps.try-nix-shell-bash.outcome == 'success' && steps.try-nix-shell-bash.outputs.bash) || 'unreachable' }} {0}"
+      run: |
+        BASH_PATH="${{ (steps.try-bash.outcome == 'success' && steps.try-bash.outputs.bash) || (steps.try-hardcoded-bash.outcome == 'success' && steps.try-hardcoded-bash.outputs.bash) || (steps.try-nix-shell-bash.outcome == 'success' && steps.try-nix-shell-bash.outputs.bash) || 'unreachable' }}"
+        echo "bash=${BASH_PATH} --noprofile --norc -e -o pipefail {0}" >> $GITHUB_OUTPUT
+
+    - id: check-for-nix
+      shell: ${{ steps.bash-path.outputs.bash }}
       run: |
         if ! command -v nix; then
           echo "nix-missing=true" >> $GITHUB_OUTPUT
@@ -116,7 +162,7 @@ runs:
     # So, to keep things fast and simple we just vendored the `nix-direnv`
     # envrc script.
     - run: ${{ github.action_path }}/action.bash ${{ github.env }} ${{ github.path }}
-      shell: bash
+      shell: ${{ steps.bash-path.outputs.bash }}
       env:
         NIX_DIRENV_PATH: ${{ github.action_path }}/vendored/nix-direnv.envrc
 


### PR DESCRIPTION
When using multiple `nix-use-shell-action`s in a job, it's common for bash to disappear from `$PATH` or for non-interactive bash to be placed on `$PATH` (which lacks `compgen` which `action.bash` needs).

Users _can_ work around this by remembering to add `bashInteractive` to their shells put it'd be better if we just handled this.